### PR TITLE
Refactor after core update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 export_files
+.vscode
 
 
 # Added by cargo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,21 +3,6 @@
 version = 3
 
 [[package]]
-name = "accrete"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "275ad116653f380a50a50ca8feebd573d2815da8592b6ce167f47f143c5ece85"
-dependencies = [
- "console_error_panic_hook",
- "getrandom",
- "rand",
- "rand_chacha",
- "serde",
- "wasm-bindgen",
- "wee_alloc",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,18 +60,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,16 +112,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
-name = "console_error_panic_hook"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
-dependencies = [
- "cfg-if 1.0.0",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "csv"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,19 +137,6 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
-
-[[package]]
-name = "getrandom"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
-dependencies = [
- "cfg-if 1.0.0",
- "js-sys",
- "libc",
- "wasi",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "hashbrown"
@@ -217,15 +167,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
-name = "js-sys"
-version = "0.3.68"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
-dependencies = [
- "wasm-bindgen",
-]
-
-[[package]]
 name = "kepler_cli"
 version = "0.1.0"
 dependencies = [
@@ -241,10 +182,9 @@ dependencies = [
 
 [[package]]
 name = "kepler_core"
-version = "0.1.0"
-source = "git+https://github.com/keplerplanetary/kepler_core.git#aab6dcd70246a53e9002c457a0f20032bf830a71"
+version = "0.2.0"
+source = "git+https://github.com/keplerplanetary/kepler_core.git#545ca8831b3f865d02ea4a1fa28146fe0e1d0e2a"
 dependencies = [
- "accrete",
  "maths-rs",
  "serde",
 ]
@@ -254,12 +194,6 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
-name = "libc"
-version = "0.2.153"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "log"
@@ -293,12 +227,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
-name = "memory_units"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,12 +255,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,37 +270,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
- "serde",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom",
 ]
 
 [[package]]
@@ -509,7 +400,7 @@ version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "once_cell",
 ]
 
@@ -625,80 +516,6 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.91"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
-dependencies = [
- "cfg-if 1.0.0",
- "serde",
- "serde_json",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.91"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
-dependencies = [
- "bumpalo",
- "log",
- "once_cell",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.91"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.91"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.91"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
-
-[[package]]
-name = "wee_alloc"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb3b5a6b2bb17cb6ad44a2e68a43e8d2722c997da10e928665c72ec6c0a0b8e"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "memory_units",
- "winapi",
-]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-kepler_core = {git= "https://github.com/keplerplanetary/kepler_core.git"}
+kepler_core = { git= "https://github.com/keplerplanetary/kepler_core.git" }
 toml = "0.8.9"
 maths-rs = "0.2.6"
 csv = "1.3.0"

--- a/src/configsystem.rs
+++ b/src/configsystem.rs
@@ -1,4 +1,4 @@
-use kepler_core::System;
+use kepler_core::types::System;
 use serde::{Deserialize, Serialize};
 use std::{fs::File, io::Read};
 

--- a/src/export.rs
+++ b/src/export.rs
@@ -1,9 +1,9 @@
-use kepler_core::System;
+use kepler_core::types::System;
 use std::{
     error::Error,
     fs::{DirBuilder, OpenOptions},
     io::Write,
-    path::{Path, PathBuf},
+    path::Path,
 };
 
 use crate::configsystem::Config;

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -73,21 +73,69 @@ pub fn run_simulation(config: Config, initial_system: System) {
 }
 
 fn format_time(time: u64) -> String {
-    if time < 60 {
+    let one_min = 60;
+    let one_hour = one_min * 60; // 3600 seconds
+    let one_day = one_hour * 24; // 86_400 seconds
+    let one_month = one_day * 30; // 2_592_000 seconds
+    let one_year = one_month * 12; // 31_104_000 seconds
+    if time < one_min {
         format!("{:.2}s", time)
-    } else if 60 <= time && time < 3600 {
+    } else if (one_min..one_hour).contains(&time) {
         // 1 minute to 1 hour
-        format!("{:.2}min", time.as_f64() / 60.0)
-    } else if 3600 <= time && time < 68400 {
+        format!("{:.2}min", time.as_f64() / one_min as f64)
+    } else if (one_hour..one_day).contains(&time) {
         // 1 hour to 1 day
-        format!("{:.2}h", time.as_f64() / 3600.0)
-    } else if 68400 <= time && time < 2592000 {
+        format!("{:.2}h", time.as_f64() / one_hour as f64)
+    } else if (one_day..one_month).contains(&time) {
         // 1 day to 1 month
-        format!("{:.2}months", time.as_f64() / 68400.0)
-    } else if 2592000 <= time && time < 31104000 {
+        format!("{:.2}days", time.as_f64() / one_day as f64)
+    } else if (one_month..one_year).contains(&time) {
         // 1 month to 1 year
-        format!("{:.2}y", time.as_f64() / 2592000.0)
+        format!("{:.2}months", time.as_f64() / one_month as f64)
+    } else if time > one_year {
+        format!("{:.2}y", time.as_f64() / one_year as f64)
     } else {
-        return "?".to_owned();
+        "?".to_owned()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::format_time;
+
+    #[test]
+    pub fn correctly_formats_time() {
+        let seconds = 86_400;
+        let expected_output = "1.00days".to_string();
+        let actual_output = format_time(seconds);
+        assert_eq!(expected_output, actual_output);
+        let seconds = 86_399;
+        let expected_output = "24.00h".to_string();
+        let actual_output = format_time(seconds);
+        assert_eq!(expected_output, actual_output);
+        let seconds = 86_300;
+        let expected_output = "23.97h".to_string();
+        let actual_output = format_time(seconds);
+        assert_eq!(expected_output, actual_output);
+        let seconds = 360;
+        let expected_output = "6.00min".to_string();
+        let actual_output = format_time(seconds);
+        assert_eq!(expected_output, actual_output);
+        let seconds = 2_500_000;
+        let expected_output = "28.94days".to_string();
+        let actual_output = format_time(seconds);
+        assert_eq!(expected_output, actual_output);
+        let seconds = 2_592_000;
+        let expected_output = "1.00months".to_string();
+        let actual_output = format_time(seconds);
+        assert_eq!(expected_output, actual_output);
+        let seconds = (31_104_000.0 * 15.5) as u64; // 15.5 years
+        let expected_output = "15.50y".to_string();
+        let actual_output = format_time(seconds);
+        assert_eq!(expected_output, actual_output);
+        let seconds = 1234567890;
+        let expected_output = "39.69y".to_string();
+        let actual_output = format_time(seconds);
+        assert_eq!(expected_output, actual_output);
     }
 }

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -1,4 +1,4 @@
-use kepler_core::{system_timestep, System};
+use kepler_core::{energy::calculate_system_energy, mover::system_timestep, types::System};
 use maths_rs::num::Cast;
 
 use crate::{
@@ -59,7 +59,7 @@ pub fn run_simulation(config: Config, initial_system: System) {
 
             let human_readable_time = format_time(time.as_u64());
             let progress = i.as_f64() / config.steps.as_f64() * 100.0;
-            let energy: f64 = kepler_core::calculate_system_energy(system.clone());
+            let energy: f64 = calculate_system_energy(system.clone());
 
             tracing::event!(
                 tracing::Level::INFO,

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -72,6 +72,9 @@ pub fn run_simulation(config: Config, initial_system: System) {
     }
 }
 
+/// This function formats time in seconds in a human readable format.
+/// It assumes one month is 30 days and one year is 12 * 30 days,
+/// so it's not extremely precise.
 fn format_time(time: u64) -> String {
     let one_min = 60;
     let one_hour = one_min * 60; // 3600 seconds


### PR DESCRIPTION
I updated the imports from `kepler_core` and also refactored the `format_time` function a bit. There were a couple issues with it, and I made it more readable. I also added a test for it, but the test looks a bit long. I think we could package up the test cases into a data structure and iterate over them so it will not look so messy.