### PR TITLE
Improve csv output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,9 +67,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.4.18"
+version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
+checksum = "c918d541ef2913577a0f9566e9ce27cb35b6df072075769e0b26cb5a554520da"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -77,9 +77,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.18"
+version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
+checksum = "9f3e7391dad68afb0c2ede1bf619f579a3dc9c2ec67f089baa397123a2f3d1eb"
 dependencies = [
  "anstream",
  "anstyle",
@@ -89,9 +89,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.4.7"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -101,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "colorchoice"
@@ -152,9 +152,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "indexmap"
-version = "2.2.2"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
+checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -183,7 +183,7 @@ dependencies = [
 [[package]]
 name = "kepler_core"
 version = "0.2.0"
-source = "git+https://github.com/keplerplanetary/kepler_core.git#545ca8831b3f865d02ea4a1fa28146fe0e1d0e2a"
+source = "git+https://github.com/keplerplanetary/kepler_core.git#6104c5a50e8f249db6ce9073035e2598ac5ea104"
 dependencies = [
  "maths-rs",
  "serde",
@@ -379,15 +379,15 @@ checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "915aea9e586f80826ee59f8453c1101f9d1c4b3964cd2460185ee8e299ada496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -427,9 +427,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.4"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9ffdf896f8daaabf9b66ba8e77ea1ed5ed0f72821b398aba62352e95062951"
+checksum = "2c1b5fd4128cc8d3e0cb74d4ed9a9cc7c7284becd4df68f5f940e1ad123606f6"
 dependencies = [
  "indexmap",
  "serde",
@@ -607,9 +607,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.39"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5389a154b01683d28c77f8f68f49dea75f0a4da32557a58f68ee51ebba472d29"
+checksum = "d90f4e0f530c4c69f62b80d839e9ef3855edc9cba471a160c4d692deed62b401"
 dependencies = [
  "memchr",
 ]

--- a/example.toml
+++ b/example.toml
@@ -6,7 +6,7 @@ export_directory = "export_files"
 export_file_name_prefix = "SIM"
 export_system_state = false # defaults to false
 export_body_history = true # defaults to false
-
+export_system_parameters_history = true # defaults to false
 
 [[system.bodies]]
 name = "Sun"

--- a/example.toml
+++ b/example.toml
@@ -4,6 +4,9 @@ steps = 15234
 export_step = 10
 export_directory = "export_files"
 export_file_name_prefix = "SIM"
+export_system_state = false # defaults to false
+export_body_history = true # defaults to false
+
 
 [[system.bodies]]
 name = "Sun"

--- a/example.toml
+++ b/example.toml
@@ -1,7 +1,7 @@
 [config]
 timestep = 400.0
-steps = 15234
-export_step = 10
+steps = 152345
+export_step = 1000
 export_directory = "export_files"
 export_file_name_prefix = "SIM"
 export_system_state = false # defaults to false

--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 run:
-	cargo run -- -f example.toml
+	RUST_LOG=info cargo run -- -f example.toml
 
 clean: 
 	rm -r export_files

--- a/src/configsystem.rs
+++ b/src/configsystem.rs
@@ -15,6 +15,8 @@ pub struct Config {
     pub export_system_state: bool,
     #[serde(default)]
     pub export_body_history: bool,
+    #[serde(default)]
+    pub export_system_parameters_history: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/configsystem.rs
+++ b/src/configsystem.rs
@@ -11,6 +11,10 @@ pub struct Config {
     pub export_step: i64,
     pub export_directory: String,
     pub export_file_name_prefix: String,
+    #[serde(default)]
+    pub export_system_state: bool,
+    #[serde(default)]
+    pub export_body_history: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/export.rs
+++ b/src/export.rs
@@ -119,12 +119,9 @@ pub fn export_system_to_csv_by_body(
         ))?;
 
         // here we remove the generated newline character from the csv library so that we can use writeln below.
-        let text = String::from_utf8(wtr.into_inner()?)?.replace("\n", "");
+        let text = String::from_utf8(wtr.into_inner()?)?.replace('\n', "");
 
-        let mut file = OpenOptions::new()
-            .write(true)
-            .append(true)
-            .open(&fullpath)?;
+        let mut file = OpenOptions::new().append(true).open(&fullpath)?;
         writeln!(file, "{}", text)?;
     }
 
@@ -208,19 +205,16 @@ pub fn export_system_parameters_to_csv(
     ))?;
 
     // here we remove the generated newline character from the csv library so that we can use writeln below.
-    let text = String::from_utf8(wtr.into_inner()?)?.replace("\n", "");
+    let text = String::from_utf8(wtr.into_inner()?)?.replace('\n', "");
 
-    let mut file = OpenOptions::new()
-        .write(true)
-        .append(true)
-        .open(&fullpath)?;
+    let mut file = OpenOptions::new().append(true).open(&fullpath)?;
     writeln!(file, "{}", text)?;
 
     Ok(())
 }
 
 fn write_csv_headers(fullpath: &PathBuf, headers: &Vec<String>) -> Result<(), Box<dyn Error>> {
-    let mut wtr = csv::Writer::from_path(&fullpath)?;
+    let mut wtr = csv::Writer::from_path(fullpath)?;
     wtr.write_record(headers)?;
     wtr.flush()?;
     Ok(())

--- a/src/export.rs
+++ b/src/export.rs
@@ -71,7 +71,7 @@ pub fn export_system_to_csv_by_body(
     }
 
     for body in system.bodies {
-        let filename = format! {"{}.csv", body.name};
+        let filename = format! {"{}_{}.csv", config.export_file_name_prefix, body.name};
         let filename_path = Path::new(&filename);
         let fullpath = path.join(filename_path);
 

--- a/src/export.rs
+++ b/src/export.rs
@@ -12,8 +12,8 @@ use std::{
 use crate::configsystem::Config;
 
 pub fn export_system_snapshot_to_csv(
-    config: Config,
-    system: System,
+    config: &Config,
+    system: &System,
     step: i64,
     time: f64,
 ) -> Result<(), Box<dyn Error>> {
@@ -37,10 +37,10 @@ pub fn export_system_snapshot_to_csv(
 
     wtr.write_record(&headers)?;
 
-    for body in system.bodies {
+    for body in system.bodies.iter() {
         wtr.serialize((
             time,
-            body.name,
+            body.name.clone(),
             body.mass,
             body.position.x,
             body.position.y,
@@ -54,8 +54,8 @@ pub fn export_system_snapshot_to_csv(
 }
 
 pub fn export_system_to_csv_by_body(
-    config: Config,
-    system: System,
+    config: &Config,
+    system: &System,
     step: i64,
     time: f64,
 ) -> Result<(), Box<dyn Error>> {
@@ -73,7 +73,7 @@ pub fn export_system_to_csv_by_body(
             .expect("That the export path could be created.");
     }
 
-    for body in system.bodies {
+    for body in system.bodies.iter() {
         let filename = format! {"{}_{}.csv", config.export_file_name_prefix, body.name};
         let filename_path = Path::new(&filename);
         let fullpath = path.join(filename_path);

--- a/src/export.rs
+++ b/src/export.rs
@@ -1,4 +1,7 @@
-use kepler_core::types::System;
+use kepler_core::{
+    center_of_mass::calculate_center_of_mass, energy::calculate_system_energy,
+    impulse::calculate_total_impulse, types::System,
+};
 use std::{
     error::Error,
     fs::{DirBuilder, OpenOptions},
@@ -124,6 +127,94 @@ pub fn export_system_to_csv_by_body(
             .open(&fullpath)?;
         writeln!(file, "{}", text)?;
     }
+
+    Ok(())
+}
+
+pub fn export_system_parameters_to_csv(
+    config: &Config,
+    system: &System,
+    step: i64,
+    time: f64,
+) -> Result<(), Box<dyn Error>> {
+    let headers: Vec<String> = vec![
+        "Step",
+        "Time",
+        "Energy",
+        "Impulse x",
+        "Impulse y",
+        "Center of mass x",
+        "Center of mass y",
+    ]
+    .into_iter()
+    .map(|s| s.to_owned())
+    .collect();
+
+    let path = Path::new(&config.export_directory);
+
+    if !path.exists() {
+        DirBuilder::new()
+            .recursive(true)
+            .create(path)
+            .expect("That the export path could be created.");
+    }
+
+    let filename = format! {"{}_system_parameters.csv", config.export_file_name_prefix};
+    let filename_path = Path::new(&filename);
+    let fullpath = path.join(filename_path);
+
+    // first, check if the object we want to write to exists, and if it does, if it is a file
+    match std::fs::metadata(&fullpath) {
+        Ok(metadata) => {
+            if metadata.is_file() {
+                if step == 0 {
+                    // overwrite the file with fresh headers
+                    write_csv_headers(&fullpath, &headers)?;
+                }
+                // nothing to do, we can go ahead
+            } else {
+                // we would like to write to something that exists, but it's not a file
+                // so we return a file not found error
+                return Err(Box::new(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!(
+                        "The destination file object already exists, but it is not a file: {}",
+                        fullpath
+                            .to_str()
+                            .expect("that the path can be formatted as str")
+                    ),
+                )));
+            }
+        }
+        Err(_e) => {
+            // if the fs object we want to write to does not exist, we create a file and write the csv headers
+            write_csv_headers(&fullpath, &headers)?;
+        }
+    }
+
+    // in any case, we write a new line to the export file, possibly after creating it first
+    let mut wtr = csv::Writer::from_writer(vec![]);
+
+    let total_impulse = calculate_total_impulse(system);
+    let center_of_mass = calculate_center_of_mass(system);
+    wtr.serialize((
+        step,
+        time,
+        calculate_system_energy(system),
+        total_impulse.x,
+        total_impulse.y,
+        center_of_mass.x,
+        center_of_mass.y,
+    ))?;
+
+    // here we remove the generated newline character from the csv library so that we can use writeln below.
+    let text = String::from_utf8(wtr.into_inner()?)?.replace("\n", "");
+
+    let mut file = OpenOptions::new()
+        .write(true)
+        .append(true)
+        .open(&fullpath)?;
+    writeln!(file, "{}", text)?;
 
     Ok(())
 }

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -1,4 +1,4 @@
-use kepler_core::{energy::calculate_system_energy, mover::system_timestep, types::System};
+use kepler_core::{mover::system_timestep, types::System};
 use maths_rs::num::Cast;
 
 use crate::{

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -11,51 +11,62 @@ pub fn run_simulation(config: Config, initial_system: System) {
 
     let mut time = 0.0;
 
-    match export_system_snapshot_to_csv(config.clone(), system.clone(), 0, time) {
-        Ok(_) => {
-            tracing::event!(tracing::Level::DEBUG, "Exported 0, time {time}s");
-        }
-        Err(e) => {
-            tracing::event!(tracing::Level::ERROR, "error while exporting {e}");
+    if config.export_system_state {
+        match export_system_snapshot_to_csv(config.clone(), system.clone(), 0, time) {
+            Ok(_) => {
+                tracing::event!(tracing::Level::DEBUG, "Exported 0, time {time}s");
+            }
+            Err(e) => {
+                tracing::event!(tracing::Level::ERROR, "error while exporting {e}");
 
-            println!("error while exporting {e}");
-            return;
-        }
-    };
-    match export_system_to_csv_by_body(config.clone(), system.clone(), 0, time) {
-        Ok(_) => {
-            tracing::event!(tracing::Level::DEBUG, "Exported 0, time {time}s");
-        }
-        Err(e) => {
-            tracing::event!(tracing::Level::ERROR, "error while exporting {e}");
+                println!("error while exporting {e}");
+                return;
+            }
+        };
+    }
 
-            println!("error while exporting {e}");
-            return;
-        }
-    };
+    if config.export_body_history {
+        match export_system_to_csv_by_body(config.clone(), system.clone(), 0, time) {
+            Ok(_) => {
+                tracing::event!(tracing::Level::DEBUG, "Exported 0, time {time}s");
+            }
+            Err(e) => {
+                tracing::event!(tracing::Level::ERROR, "error while exporting {e}");
+
+                println!("error while exporting {e}");
+                return;
+            }
+        };
+    }
+
     for i in 1..config.steps + 1 {
         system = system_timestep(system, config.timestep);
         time += config.timestep;
 
         if i % config.export_step == 0 {
-            match export_system_snapshot_to_csv(config.clone(), system.clone(), i, time) {
-                Ok(_) => {
-                    tracing::event!(tracing::Level::DEBUG, "Exported 0, time {time}s");
-                }
-                Err(e) => {
-                    tracing::event!(tracing::Level::ERROR, "error while exporting {e}");
-                    return;
-                }
-            };
-            match export_system_to_csv_by_body(config.clone(), system.clone(), i, time) {
-                Ok(_) => {
-                    tracing::event!(tracing::Level::DEBUG, "Exported 0, time {time}s");
-                }
-                Err(e) => {
-                    tracing::event!(tracing::Level::ERROR, "error while exporting {e}");
-                    return;
-                }
-            };
+            if config.export_system_state {
+                match export_system_snapshot_to_csv(config.clone(), system.clone(), i, time) {
+                    Ok(_) => {
+                        tracing::event!(tracing::Level::DEBUG, "Exported 0, time {time}s");
+                    }
+                    Err(e) => {
+                        tracing::event!(tracing::Level::ERROR, "error while exporting {e}");
+                        return;
+                    }
+                };
+            }
+
+            if config.export_body_history {
+                match export_system_to_csv_by_body(config.clone(), system.clone(), i, time) {
+                    Ok(_) => {
+                        tracing::event!(tracing::Level::DEBUG, "Exported 0, time {time}s");
+                    }
+                    Err(e) => {
+                        tracing::event!(tracing::Level::ERROR, "error while exporting {e}");
+                        return;
+                    }
+                };
+            }
 
             let human_readable_time = format_time(time.as_u64());
             let progress = i.as_f64() / config.steps.as_f64() * 100.0;

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -25,7 +25,7 @@ pub fn run_simulation(config: Config, initial_system: System) {
         };
     }
     if config.export_system_state {
-        match export_system_snapshot_to_csv(config.clone(), system.clone(), 0, time) {
+        match export_system_snapshot_to_csv(&config, &system, 0, time) {
             Ok(_) => {
                 tracing::event!(tracing::Level::DEBUG, "Exported 0, time {time}s");
             }
@@ -39,7 +39,7 @@ pub fn run_simulation(config: Config, initial_system: System) {
     }
 
     if config.export_body_history {
-        match export_system_to_csv_by_body(config.clone(), system.clone(), 0, time) {
+        match export_system_to_csv_by_body(&config, &system, 0, time) {
             Ok(_) => {
                 tracing::event!(tracing::Level::DEBUG, "Exported 0, time {time}s");
             }
@@ -69,7 +69,7 @@ pub fn run_simulation(config: Config, initial_system: System) {
                 };
             }
             if config.export_system_state {
-                match export_system_snapshot_to_csv(config.clone(), system.clone(), i, time) {
+                match export_system_snapshot_to_csv(&config, &system, i, time) {
                     Ok(_) => {
                         tracing::event!(tracing::Level::DEBUG, "Exported 0, time {time}s");
                     }
@@ -81,7 +81,7 @@ pub fn run_simulation(config: Config, initial_system: System) {
             }
 
             if config.export_body_history {
-                match export_system_to_csv_by_body(config.clone(), system.clone(), i, time) {
+                match export_system_to_csv_by_body(&config, &system, i, time) {
                     Ok(_) => {
                         tracing::event!(tracing::Level::DEBUG, "Exported 0, time {time}s");
                     }


### PR DESCRIPTION
This change makes all exports configurable by the configuration file. The example configuration file is extended with all relevant information.

I added an export that writes energy, impulse and center of mass to a single file for the whole system.

All export files now respect the prefix. This allows us to repeat a simulation with different parameters to the same folder without overwriting the files.

The exports that append to csv files now have only one codeblock that writes simulation information. So if we extend it in the future we only need to do it in one place.

Additionally, all export functions take references to system and body. There is only one clone remaining when writing the bodys name to file.

