### PR TITLE
improve plot output

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ Thread 'main' panicked at ~/.cargo/registry/src/index.crates.io-6f17d22bba15001f
   called `Result::unwrap()` on an `Err` value: "\npkg-config exited with status code 1\n> PKG_CONFIG_ALLOW_SYSTEM_LIBS=1 PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1 pkg-config --libs --cflags fontconfig\n\nThe system library `fontconfig` required by crate `yeslogic-fontconfig-sys` was not found.\nThe file `fontconfig.pc` needs to be installed and the PKG_CONFIG_PATH environment variable must contain its parent directory.\nThe PKG_CONFIG_PATH environment variable is not set.\n\nHINT: if you have installed the library, try setting PKG_CONFIG_PATH to the directory containing `fontconfig.pc`.\n"
 ```
 
-You may need to install libfontconfig1-dev.
+You may need to install `libfontconfig1-dev`.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# CLI for Kepler
+
+## Development
+
+If you get this error on Linux while trying to build the project or (in my case, rust-analyzer in VSCode gave the error)...
+
+```
+Thread 'main' panicked at ~/.cargo/registry/src/index.crates.io-6f17d22bba15001f/yeslogic-fontconfig-sys-3.2.0/build.rs:8:48:
+  called `Result::unwrap()` on an `Err` value: "\npkg-config exited with status code 1\n> PKG_CONFIG_ALLOW_SYSTEM_LIBS=1 PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1 pkg-config --libs --cflags fontconfig\n\nThe system library `fontconfig` required by crate `yeslogic-fontconfig-sys` was not found.\nThe file `fontconfig.pc` needs to be installed and the PKG_CONFIG_PATH environment variable must contain its parent directory.\nThe PKG_CONFIG_PATH environment variable is not set.\n\nHINT: if you have installed the library, try setting PKG_CONFIG_PATH to the directory containing `fontconfig.pc`.\n"
+```
+
+You may need to install libfontconfig1-dev.

--- a/example.toml
+++ b/example.toml
@@ -7,6 +7,9 @@ export_file_name_prefix = "SIM"
 export_system_state = false # defaults to false
 export_body_history = true # defaults to false
 export_system_parameters_history = true # defaults to false
+plot_system = true # defaults to false
+plot_system_kinetic_energy = true # defaults to false
+plot_system_potential_energy = false # defaults to false
 
 [[system.bodies]]
 name = "Sun"

--- a/src/configsystem.rs
+++ b/src/configsystem.rs
@@ -17,6 +17,12 @@ pub struct Config {
     pub export_body_history: bool,
     #[serde(default)]
     pub export_system_parameters_history: bool,
+    #[serde(default)]
+    pub plot_system: bool,
+    #[serde(default)]
+    pub plot_system_kinetic_energy: bool,
+    #[serde(default)]
+    pub plot_system_potential_energy: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ mod plot;
 
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
-/// Simple program to greet a person
+/// Command line interface for the Kepler planetary motion simulator
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {

--- a/src/plot.rs
+++ b/src/plot.rs
@@ -74,7 +74,7 @@ pub fn plot_total_energy(
     y_min_kinetic_energy *= 0.95;
     let y_min_energy = min(y_min_potential_energy, y_min_kinetic_energy);
 
-    let y_label_size = root_drawing_area
+    let label_size = root_drawing_area
         .estimate_text_size(
             &format_label(&y_max_total_energy),
             &TextStyle {
@@ -87,24 +87,11 @@ pub fn plot_total_energy(
             },
         )
         .expect("Should be able to estimate the text size");
-    let x_label_size = root_drawing_area
-        .estimate_text_size(
-            &format_label(&y_max_total_energy),
-            &TextStyle {
-                font: ("Sans-serif", 15).into_font(),
-                color: BLACK.to_backend_color(),
-                pos: Pos {
-                    h_pos: plotters::style::text_anchor::HPos::Center,
-                    v_pos: plotters::style::text_anchor::VPos::Center,
-                },
-            },
-        )
-        .expect("Should be able to estimate the text size");
 
     let mut chart_context = ChartBuilder::on(&root_drawing_area)
         .caption("System Energy over Time", ("Sans-serif", 20).into_font())
-        .x_label_area_size(x_label_size.0)
-        .y_label_area_size(y_label_size.0)
+        .x_label_area_size(label_size.0)
+        .y_label_area_size(label_size.0)
         .build_cartesian_2d(x_min..x_max, y_min_energy..y_max_total_energy)?;
 
     chart_context

--- a/src/plot.rs
+++ b/src/plot.rs
@@ -126,8 +126,8 @@ pub fn plot_total_energy(
         .y_labels(6)
         .x_label_formatter(&format_label)
         .y_label_formatter(&format_label)
-        .x_desc("Time (s)")
-        .y_desc("Energy (J?)")
+        .x_desc("Time / s")
+        .y_desc("Energy / J")
         .draw()?;
 
     let total_energy_series_annotation = chart_context.draw_series(LineSeries::new(

--- a/src/plot.rs
+++ b/src/plot.rs
@@ -100,24 +100,33 @@ pub fn plot_total_energy(
         }
     }
 
-    let label_size = root_drawing_area
-        .estimate_text_size(
-            &format_label(&y_max_total_energy),
-            &TextStyle {
-                font: ("Sans-serif", 20).into_font(),
-                color: BLACK.to_backend_color(),
-                pos: Pos {
-                    h_pos: plotters::style::text_anchor::HPos::Center,
-                    v_pos: plotters::style::text_anchor::VPos::Center,
-                },
+    let y_label_size = root_drawing_area.estimate_text_size(
+        &format_label(&y_max_total_energy),
+        &TextStyle {
+            font: ("Sans-serif", 20).into_font(),
+            color: BLACK.to_backend_color(),
+            pos: Pos {
+                h_pos: plotters::style::text_anchor::HPos::Center,
+                v_pos: plotters::style::text_anchor::VPos::Center,
             },
-        )
-        .expect("Should be able to estimate the text size");
+        },
+    )?;
+    let x_label_size = root_drawing_area.estimate_text_size(
+        &format_label(&x_max),
+        &TextStyle {
+            font: ("Sans-serif", 15).into_font(),
+            color: BLACK.to_backend_color(),
+            pos: Pos {
+                h_pos: plotters::style::text_anchor::HPos::Center,
+                v_pos: plotters::style::text_anchor::VPos::Center,
+            },
+        },
+    )?;
 
     let mut chart_context = ChartBuilder::on(&root_drawing_area)
         .caption("System Energy over Time", ("Sans-serif", 20).into_font())
-        .x_label_area_size(label_size.0)
-        .y_label_area_size(label_size.0)
+        .x_label_area_size(x_label_size.0)
+        .y_label_area_size(y_label_size.0)
         .build_cartesian_2d(x_min..x_max, y_min_energy..y_max_total_energy)?;
 
     chart_context

--- a/src/plot.rs
+++ b/src/plot.rs
@@ -41,7 +41,7 @@ pub fn plot_total_energy(
     root_drawing_area
         .fill(&WHITE)
         .expect("Should be able to fill the drawing area with white");
-    let root_drawing_area = root_drawing_area.margin(20, 20, 20, 20);
+    let root_drawing_area = root_drawing_area.margin(20, 20, 20, 40);
     let total_energy_color = RED;
     let potential_energy_color = BLUE;
     let kinetic_energy_color = GREEN;
@@ -50,7 +50,7 @@ pub fn plot_total_energy(
         .iter()
         .map(|e| e.time)
         .fold(f64::INFINITY, |a, b| a.min(b));
-    let mut x_max = data
+    let x_max = data
         .iter()
         .map(|e| e.time)
         .fold(-f64::INFINITY, |a, b| a.max(b));
@@ -68,7 +68,7 @@ pub fn plot_total_energy(
         .fold(f64::INFINITY, |a, b| a.min(b));
     // add 5% padding around the max and min values
     x_min *= 0.95;
-    x_max *= 1.05;
+    // x_max *= 1.05; // max time should not be padded
     y_max_total_energy *= 1.05;
     y_min_potential_energy *= 0.95;
     y_min_kinetic_energy *= 0.95;
@@ -113,8 +113,8 @@ pub fn plot_total_energy(
         .y_labels(6)
         .x_label_formatter(&format_label)
         .y_label_formatter(&format_label)
-        .y_desc("Time (s)")
-        .x_desc("Total Energy (J?)")
+        .x_desc("Time (s)")
+        .y_desc("Energy (J?)")
         .draw()?;
 
     let total_energy_series_annotation = chart_context.draw_series(LineSeries::new(

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -130,7 +130,17 @@ pub fn run_simulation(config: Config, initial_system: System) {
         }
     }
 
-    plot_total_energy(energy_plot_data, &config);
+    match plot_total_energy(energy_plot_data, &config) {
+        Ok(_) => {
+            tracing::event!(tracing::Level::INFO, "Plotted total energy");
+        }
+        Err(e) => {
+            tracing::event!(
+                tracing::Level::ERROR,
+                "Error while plotting total energy: {e}"
+            );
+        }
+    };
 }
 
 /// This function formats time in seconds in a human readable format.

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -1,4 +1,8 @@
-use kepler_core::{energy::calculate_system_energy, mover::system_timestep, types::System};
+use kepler_core::{
+    energy::{calculate_kinetic_energy, calculate_potential_energy, calculate_system_energy},
+    mover::system_timestep,
+    types::System,
+};
 use maths_rs::num::Cast;
 
 use crate::{
@@ -64,6 +68,18 @@ pub fn run_simulation(config: Config, initial_system: System) {
             energy_plot_data.push(PlotDatum {
                 time,
                 total_energy: calculate_system_energy(&system),
+                kinetic_energy: system.bodies.iter().map(calculate_kinetic_energy).sum(),
+                potential_energy: system
+                    .bodies
+                    .iter()
+                    .map(|body| {
+                        system
+                            .bodies
+                            .iter()
+                            .map(|other| calculate_potential_energy(body, other))
+                            .sum::<f64>()
+                    })
+                    .sum::<f64>(),
             });
 
             // writing to file

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -7,11 +7,11 @@ use crate::{
         export_system_parameters_to_csv, export_system_snapshot_to_csv,
         export_system_to_csv_by_body,
     },
-    plot::plot_total_energy,
+    plot::{plot_total_energy, PlotDatum},
 };
 
 pub fn run_simulation(config: Config, initial_system: System) {
-    let mut energy_plot_data: Vec<(f64, f64)> = vec![];
+    let mut energy_plot_data: Vec<PlotDatum> = vec![];
 
     let mut system = initial_system.clone();
 
@@ -61,8 +61,10 @@ pub fn run_simulation(config: Config, initial_system: System) {
 
         if i % config.export_step == 0 {
             // save data for plotting
-
-            energy_plot_data.push((time, calculate_system_energy(&system)));
+            energy_plot_data.push(PlotDatum {
+                time,
+                total_energy: calculate_system_energy(&system),
+            });
 
             // writing to file
             if config.export_system_parameters_history {


### PR DESCRIPTION
This changes from using a tuple of two f64s to a struct called a PlotDatum. Now it includes time and total_energy, but next we'll add the potential and kinetic energy separately, too.

We also now show the x and y values in scientific form if they are large numbers. That and using the plotters function to estimate the size of the text label helps the x and y axes look cleaner and easier to read.

We also now log DrawingAreaErrors instead of unwrapping them. Docs for those errors [here](https://docs.rs/plotters/0.3.5/plotters/drawing/enum.DrawingAreaErrorKind.html).